### PR TITLE
Create structure for Unit Tests

### DIFF
--- a/GT.sln
+++ b/GT.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.32002.185
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -9,6 +9,12 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GT.Data", "src\GT.Data\GT.Data.csproj", "{5759A2ED-B437-4AAA-959E-974E5E25B190}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GT.Core", "src\GT.Core\GT.Core.csproj", "{C8951C7B-17D0-45ED-B8AA-E6C606FAD292}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{CB161F81-B13A-487C-96B1-484242F9DB27}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "UnitTests", "UnitTests", "{643332CE-C333-461D-8328-E148C84AF33B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GT.Core.Tests", "tests\UnitTests\GT.Core.Tests\GT.Core.Tests.csproj", "{3FEAA3B1-DDA1-43D2-96C9-D6BF8C1A18D7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -28,6 +34,10 @@ Global
 		{C8951C7B-17D0-45ED-B8AA-E6C606FAD292}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8951C7B-17D0-45ED-B8AA-E6C606FAD292}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8951C7B-17D0-45ED-B8AA-E6C606FAD292}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3FEAA3B1-DDA1-43D2-96C9-D6BF8C1A18D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3FEAA3B1-DDA1-43D2-96C9-D6BF8C1A18D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3FEAA3B1-DDA1-43D2-96C9-D6BF8C1A18D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3FEAA3B1-DDA1-43D2-96C9-D6BF8C1A18D7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -36,6 +46,8 @@ Global
 		{D916F97B-534B-48BC-BB13-CFE956FF153E} = {78D6EA98-79C1-48E6-B9F7-DEB9DD3CD891}
 		{5759A2ED-B437-4AAA-959E-974E5E25B190} = {78D6EA98-79C1-48E6-B9F7-DEB9DD3CD891}
 		{C8951C7B-17D0-45ED-B8AA-E6C606FAD292} = {78D6EA98-79C1-48E6-B9F7-DEB9DD3CD891}
+		{643332CE-C333-461D-8328-E148C84AF33B} = {CB161F81-B13A-487C-96B1-484242F9DB27}
+		{3FEAA3B1-DDA1-43D2-96C9-D6BF8C1A18D7} = {643332CE-C333-461D-8328-E148C84AF33B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0EEC84FB-1DCC-4CA0-AE64-5B82961565B4}

--- a/tests/UnitTests/GT.Core.Tests/GT.Core.Tests.csproj
+++ b/tests/UnitTests/GT.Core.Tests/GT.Core.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/UnitTests/GT.Core.Tests/GT.Core.Tests.csproj
+++ b/tests/UnitTests/GT.Core.Tests/GT.Core.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -8,7 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -18,6 +20,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\GT.Core\GT.Core.csproj" />
+    <ProjectReference Include="..\..\..\src\GT.Data\GT.Data.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/UnitTests/GT.Core.Tests/GTLocationServiceTests.cs
+++ b/tests/UnitTests/GT.Core.Tests/GTLocationServiceTests.cs
@@ -12,31 +12,32 @@ namespace GT.Core.Tests
 {
 	public class GTLocationServiceTests
 	{
-		[Fact]
-		public async Task AddAsync_AddValidNewLocation_Succeeds()
+		[Theory]
+		[InlineData("Stockholm", "shouldBeReplacedByGuid")]
+		[InlineData("Örkelljunga", null)]
+		[InlineData("東京", null)]
+		public async Task AddAsync_AddValidNewLocation_Succeeds(string? inputLocationName, string? inputLocationTempId)
 		{
 			// Arrange
-			var mockServiceLogger = new Mock<ILogger<GTLocationService>>();
-			var mockRepository = new Mock<IGTGenericRepository<Location>>();
-			var locationAsInputArgument = new Location();
-
-			mockRepository
-				.Setup(m => m.AddAsync(It.IsAny<Location>()))
-				.Callback<Location>(location => locationAsInputArgument = location)
-				.Returns(Task.FromResult(locationAsInputArgument));
-
-			var systemUnderTest = new GTLocationService(mockServiceLogger.Object, mockRepository.Object);
-			var inputLocationName = "Stockholm";
-			var inputLocationTempId = "shouldBeReplacedByGuid";
-
 			var input = new LocationDTO()
 			{
 				Id = inputLocationTempId,
 				Name = inputLocationName
 			};
 
+			var mockServiceLogger = new Mock<ILogger<GTLocationService>>();
+			var mockRepository = new Mock<IGTGenericRepository<Location>>();
+			var locationSentToRepository = new Location();
+
+			mockRepository
+				.Setup(m => m.AddAsync(It.IsAny<Location>()))
+				.Callback<Location>(location => locationSentToRepository = location)
+				.Returns(Task.FromResult(locationSentToRepository));
+
+			var sut = new GTLocationService(mockServiceLogger.Object, mockRepository.Object);
+
 			// Act
-			var result = await systemUnderTest.AddAsync(input);
+			var result = await sut.AddAsync(input);
 
 			// Assert
 			result.Id.Should().MatchRegex(@"(?im)^[{(]?[0-9A-F]{8}[-]?(?:[0-9A-F]{4}[-]?){3}[0-9A-F]{12}[)}]?$");

--- a/tests/UnitTests/GT.Core.Tests/GTLocationServiceTests.cs
+++ b/tests/UnitTests/GT.Core.Tests/GTLocationServiceTests.cs
@@ -25,6 +25,7 @@ namespace GT.Core.Tests
 				Name = inputLocationName
 			};
 
+			var guidRegex = @"(?im)^[{(]?[0-9A-F]{8}[-]?(?:[0-9A-F]{4}[-]?){3}[0-9A-F]{12}[)}]?$";
 			var mockServiceLogger = new Mock<ILogger<GTLocationService>>();
 			var mockRepository = new Mock<IGTGenericRepository<Location>>();
 			var locationSentToRepository = new Location();
@@ -40,9 +41,11 @@ namespace GT.Core.Tests
 			var result = await sut.AddAsync(input);
 
 			// Assert
-			result.Id.Should().MatchRegex(@"(?im)^[{(]?[0-9A-F]{8}[-]?(?:[0-9A-F]{4}[-]?){3}[0-9A-F]{12}[)}]?$");
+			result.Id.Should().MatchRegex(guidRegex);
+			result.Id.Should().Be(locationSentToRepository.Id);
 			result.Id.Should().NotBe(inputLocationTempId);
 			result.Name.Should().Be(inputLocationName);
+			result.Name.Should().Be(locationSentToRepository.Name);
 			mockRepository.Verify(m => m.AddAsync(It.IsAny<Location>()), Times.Once);
 		}
 	}

--- a/tests/UnitTests/GT.Core.Tests/GTLocationServiceTests.cs
+++ b/tests/UnitTests/GT.Core.Tests/GTLocationServiceTests.cs
@@ -1,0 +1,50 @@
+﻿using FluentAssertions;
+using GT.Core.DTO.Impl;
+using GT.Core.Services.Impl;
+using GT.Data.Data.GTAppDb.Entities;
+using GT.Data.Repositories.Interfaces;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace GT.Core.Tests
+{
+	public class GTLocationServiceTests
+	{
+		[Fact]
+		public async Task AddAsync_AddValidNewLocation_Succeeds()
+		{
+			// Arrange
+			var mockServiceLogger = new Mock<ILogger<GTLocationService>>();
+			var mockRepository = new Mock<IGTGenericRepository<Location>>();
+			var locationAsInputArgument = new Location();
+
+			mockRepository
+				.Setup(m => m.AddAsync(It.IsAny<Location>()))
+				.Callback<Location>(location => locationAsInputArgument = location)
+				.Returns(Task.FromResult(locationAsInputArgument));
+
+			var systemUnderTest = new GTLocationService(mockServiceLogger.Object, mockRepository.Object);
+			var inputLocationName = "Stockholm";
+			var inputLocationTempId = "shouldBeReplacedByGuid";
+
+			var input = new LocationDTO()
+			{
+				Id = inputLocationTempId,
+				Name = inputLocationName
+			};
+
+			// Act
+			var result = await systemUnderTest.AddAsync(input);
+
+			// Assert
+			result.Id.Should().MatchRegex(@"(?im)^[{(]?[0-9A-F]{8}[-]?(?:[0-9A-F]{4}[-]?){3}[0-9A-F]{12}[)}]?$");
+			result.Id.Should().NotBe(inputLocationTempId);
+			result.Name.Should().Be(inputLocationName);
+			result.Name.Should().Be(locationAsInputArgument.Name);
+
+			mockRepository.Verify(m => m.AddAsync(It.IsAny<Location>()), Times.Once);
+		}
+	}
+}

--- a/tests/UnitTests/GT.Core.Tests/GTLocationServiceTests.cs
+++ b/tests/UnitTests/GT.Core.Tests/GTLocationServiceTests.cs
@@ -26,7 +26,7 @@ namespace GT.Core.Tests
 			};
 
 			var guidRegex = @"(?im)^[{(]?[0-9A-F]{8}[-]?(?:[0-9A-F]{4}[-]?){3}[0-9A-F]{12}[)}]?$";
-			var mockServiceLogger = new Mock<ILogger<GTLocationService>>();
+			var mockLogger = new Mock<ILogger<GTLocationService>>();
 			var mockRepository = new Mock<IGTGenericRepository<Location>>();
 			var locationSentToRepository = new Location();
 
@@ -35,18 +35,22 @@ namespace GT.Core.Tests
 				.Callback<Location>(location => locationSentToRepository = location)
 				.Returns(Task.FromResult(locationSentToRepository));
 
-			var sut = new GTLocationService(mockServiceLogger.Object, mockRepository.Object);
+			var sut = new GTLocationService(mockLogger.Object, mockRepository.Object);
 
 			// Act
 			var result = await sut.AddAsync(input);
 
 			// Assert
-			result.Id.Should().MatchRegex(guidRegex);
-			result.Id.Should().Be(locationSentToRepository.Id);
-			result.Id.Should().NotBe(inputLocationTempId);
-			result.Name.Should().Be(inputLocationName);
-			result.Name.Should().Be(locationSentToRepository.Name);
 			mockRepository.Verify(m => m.AddAsync(It.IsAny<Location>()), Times.Once);
+
+			result.Id.Should()
+				.MatchRegex(guidRegex).And
+				.Be(locationSentToRepository.Id).And
+				.NotBe(inputLocationTempId);
+
+			result.Name.Should()
+				.Be(inputLocationName).And
+				.Be(locationSentToRepository.Name);
 		}
 	}
 }

--- a/tests/UnitTests/GT.Core.Tests/GTLocationServiceTests.cs
+++ b/tests/UnitTests/GT.Core.Tests/GTLocationServiceTests.cs
@@ -42,8 +42,6 @@ namespace GT.Core.Tests
 			result.Id.Should().MatchRegex(@"(?im)^[{(]?[0-9A-F]{8}[-]?(?:[0-9A-F]{4}[-]?){3}[0-9A-F]{12}[)}]?$");
 			result.Id.Should().NotBe(inputLocationTempId);
 			result.Name.Should().Be(inputLocationName);
-			result.Name.Should().Be(locationAsInputArgument.Name);
-
 			mockRepository.Verify(m => m.AddAsync(It.IsAny<Location>()), Times.Once);
 		}
 	}


### PR DESCRIPTION
#55.

Add the base folder structure for unit tests, as well as implement an initial unit test for a Service in Core layer.

PR also test how Github Actions behaves when faced with a unit test.


Current folder structure (PR):
```
/root
|__/src
   |__/Core
   |__/Data
   |__/UI
|__/tests
   |__/UnitTests
      |__/Core.Tests
```

Intended folder structure (for future reference):
```
/root
|__/src
   |__/Core
   |__/Data
   |__/UI
|__/tests
   |__/UnitTests
      |__/Core.Tests
      |__/Data.Tests
      |__/UI.Tests
   |__/IntegrationTests
etc.
```

The folder structure is very similar to the  Microsoft Docs suggested folder structure
(https://docs.microsoft.com/en-us/dotnet/core/tutorials/testing-with-cli) but takes inspiration from Ardalis interpretation of Clean Architecture (https://github.com/ardalis/CleanArchitecture/tree/main/tests).

There are other interpretations such as Jason Taylors structure (https://github.com/jasontaylordev/CleanArchitecture/tree/main/tests). I personally find the PR version to be the best implementation for our solution.
Feel free to voice your opinion if you would like to structure it differently. It is better if we have any discussions regarding structure now before accepting this PR as the process of rearranging folders can cause quite a lot of headaches further down the line. 